### PR TITLE
Feat/28 add mypage post data

### DIFF
--- a/src/components/mypage/hook/useChangeMapObject.tsx
+++ b/src/components/mypage/hook/useChangeMapObject.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { UserPostListType } from '../organism/type';
+
+const useChangeMapObject = (data: UserPostListType | undefined) => {
+  const [mapObject, setMapObject] = useState<Map<number, []>>();
+
+  useEffect(() => {
+    const mapData = new Map();
+
+    let mapObjectIndex = 0;
+
+    if (Array.isArray(data)) {
+      for (let mapObjectKey = 0; mapObjectKey <= Math.floor(data.length / 9); mapObjectKey++) {
+        mapData.set(mapObjectKey + 1, data.slice(mapObjectIndex, mapObjectIndex + 9));
+        mapObjectIndex += 9;
+      }
+
+      setMapObject(mapData);
+    }
+  }, [data]);
+
+  return [mapObject];
+};
+
+export default useChangeMapObject;

--- a/src/components/mypage/hook/usePostList.tsx
+++ b/src/components/mypage/hook/usePostList.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react';
-import { createPageDataArray } from '../../../utils/createPageDataArray';
 
-const usePostList = (pageNumber: number) => {
+const usePostList = (pageNumber: number, userPostData: Map<number, []> | undefined) => {
   const [postList, setPostList] = useState([]);
-
-  const pageData = createPageDataArray();
 
   const handlePageData = (data: Map<number, []>) => {
     const pageData = data.get(pageNumber)!;
@@ -12,8 +9,10 @@ const usePostList = (pageNumber: number) => {
   };
 
   useEffect(() => {
-    handlePageData(pageData);
-  }, [pageNumber]);
+    if (userPostData) {
+      handlePageData(userPostData);
+    }
+  }, [pageNumber, userPostData]);
 
   return { postList };
 };

--- a/src/components/mypage/hook/usePostListSize.tsx
+++ b/src/components/mypage/hook/usePostListSize.tsx
@@ -1,15 +1,13 @@
 import { useEffect, useState } from 'react';
 
-import { createPageDataArray } from '../../../utils/createPageDataArray';
-
-const usePostListSize = () => {
+const usePostListSize = (data: Map<number, []> | undefined) => {
   const [postListSize, setPostListSize] = useState(0);
 
-  const pageData = createPageDataArray();
-
   useEffect(() => {
-    setPostListSize(pageData.size);
-  }, []);
+    if (data) {
+      setPostListSize(data.size);
+    }
+  }, [data]);
 
   return { postListSize };
 };

--- a/src/components/mypage/molecules/PostContents.tsx
+++ b/src/components/mypage/molecules/PostContents.tsx
@@ -1,16 +1,27 @@
+import { Link } from 'react-router-dom';
+
 import { M } from './style';
+import { ROUTES } from '../../../router/routes';
 
 interface PostContentsProps {
+  id: number;
   title: string;
-  date: string;
+  createdAt: string;
 }
 
-const PostContents = ({ title, date }: PostContentsProps) => {
+const PostContents = ({ id, title, createdAt }: PostContentsProps) => {
   return (
-    <M.ContentsWrapper>
-      <M.Title>{title}</M.Title>
-      <M.Date>{date}</M.Date>
-    </M.ContentsWrapper>
+    <Link
+      to={{
+        pathname: `${ROUTES.CONTENTS}`,
+        search: `userId=${id}`,
+      }}
+    >
+      <M.ContentsWrapper>
+        <M.Title>{title}</M.Title>
+        <M.Date>{createdAt}</M.Date>
+      </M.ContentsWrapper>
+    </Link>
   );
 };
 

--- a/src/components/mypage/organism/type.ts
+++ b/src/components/mypage/organism/type.ts
@@ -4,4 +4,16 @@ interface StyledProps extends HTMLAttributes<HTMLButtonElement> {
   $translateValue: number;
 }
 
-export type { StyledProps };
+type UserPostListType = {
+  category: string;
+  content: string;
+  createdAt: string;
+  gender: null | string;
+  id: number;
+  nickname: string;
+  profileImg: string;
+  region: string;
+  title: string;
+};
+
+export type { StyledProps, UserPostListType };


### PR DESCRIPTION
## 분류 #28 

- [ ] 버그 수정
- [x] 신규 기능 추가
- [x] 리팩토링
- [ ] 디자인
- [ ] 코드포메팅

## Preview 이미지

## 상세내용

### 기존
- 유저 게시글 데이터 mock data 사용

### 변경 후
- 유저 게시글 데이터 fetch api 선언
- 배열로 되어 있는 유저 게시글 데이터를 map object로 변경해주는 커스텀 훅 추가(useChangeMapObject) 